### PR TITLE
Add documentation for the `--mixChannels` option to README.md and the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ cat input.wav | ssrc --stdin [options] --stdout > output.wav
 | `--att <attenuation>`      | Attenuate the output signal in decibels (dB). Default: `0`.                                    |
 | `--bits <number of bits>`  | Specify the output quantization bit depth. Common values are `16`, `24`, `32`. Use `-32` or `-64` for 32-bit or 64-bit IEEE floating-point output. Default: `16`. |
 | `--dither <type>`          | Select a dithering/noise shaping algorithm by ID. Use `--dither help` to see all available types for different sample rates. |
+| `--mixChannels <matrix>`   | Mix channels to produce a different number of output channels than the input. For example, `--mixChannels '0.5,0.5'` will mix channels 0 and 1 with a gain of 0.5 each, creating a mono output from a stereo input. `--mixChannels '1;1'` will duplicate a mono input channel to create a 2-channel stereo output. |
 | `--pdf <type> [<amp>]`     | Select a Probability Distribution Function (PDF) for dithering. `0`: Rectangular, `1`: Triangular. Default: `0`. |
 | `--profile <name>`         | Select a conversion quality/speed profile. Use `--profile help` for details. Default: `standard`. |
 | `--dstContainer <name>`    | Specify the output file container type (`riff`, `w64`, `rf64`, etc.). Use `--dstContainer help` for options. Defaults to the source container or `riff`. |

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -104,6 +104,9 @@ void showUsage(const string& argv0, const string& mes = "") {
   cerr << "                                       0    : Low intensity ATH-based noise shaping" << endl;
   cerr << "                                       98   : Triangular noise shaping" << endl;
   cerr << "                                       help : Show all available options" << endl;
+  cerr << "          --mixChannels <matrix>     Mix channels" << endl;
+  cerr << "                                       '0.5,0.5' : stereo to mono" << endl;
+  cerr << "                                       '1;1'     : mono to stereo" << endl;
   cerr << "          --pdf <type> [<amp>]       Select a probability distribution function for dithering" << endl;
   cerr << "                                       0 : Rectangular" << endl;
   cerr << "                                       1 : Triangular" << endl;


### PR DESCRIPTION
… CLI usage message.

This option allows mixing channels to produce a different number of output channels than the input. The documentation includes examples for stereo-to-mono and mono-to-stereo conversions.