### PR TITLE
Update README, manpage, and API documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ cat input.wav | ssrc --stdin [options] --stdout > output.wav
 | `--profile <name>`         | Select a conversion quality/speed profile. Use `--profile help` for details. Default: `standard`. |
 | `--minPhase`               | Use minimum-phase filters instead of the default linear-phase filters, which makes the processing delay negligible. |
 | `--partConv <log2len>`     | Divide a long filter into smaller sub-filters so that they can be applied without significant processing delays. |
+| `--st`                     | Disable multithreading (enabled by default).                                                   |
 | `--dstContainer <name>`    | Specify the output file container type (`riff`, `w64`, `rf64`, etc.). Use `--dstContainer help` for options. Defaults to the source container or `riff`. |
 | `--genImpulse ...`         | For testing. Generate an impulse signal instead of reading a file.                             |
 | `--genSweep ...`           | For testing. Generate a sweep signal instead of reading a file.                                |

--- a/src/cli/ssrc.1
+++ b/src/cli/ssrc.1
@@ -45,6 +45,9 @@ Use minimum-phase filters instead of the default linear-phase filters, which mak
 \fB--partConv <log2len>\fR
 Divide a long filter into smaller sub-filters so that they can be applied without significant processing delays.
 .TP
+\fB--st\fR
+Disable multithreading (enabled by default).
+.TP
 \fB--pdf <type> [<amp>]\fR
 Select a Probability Distribution Function (PDF) for dithering. \fB0\fR: Rectangular, \fB1\fR: Triangular. Default: \fB0\fR.
 .TP


### PR DESCRIPTION
This commit introduces several documentation updates:

1.  Documents the new `--st` command-line option in `README.md` and the `ssrc.1` manpage, clarifying that it disables the default multithreading behavior.

2.  Updates `API_DOCUMENTATION.md` to reflect the latest C++ API:
    -   Adds the `mt` boolean parameter to the `WavWriter` constructor, explaining its role in controlling multithreading for file I/O.
    -   Expands the `SSRC` constructor documentation to include and describe the `gain`, `minPhase`, `l2mindftflen`, and `mt` parameters, providing developers with a complete and accurate reference for low-latency and multithreaded configurations.