### PR TITLE
feat: Add tests for --mixChannels and --dstContainer

### DIFF
--- a/src/tester/CMakeLists.txt
+++ b/src/tester/CMakeLists.txt
@@ -282,3 +282,55 @@ add_test(NAME test_impulse_44100_48000_standard_minPhase COMMAND "${CMAKE_COMMAN
   -D COMMAND1_TO_EXECUTE=$<TARGET_FILE:scsa>\;--check\;${CMAKE_CURRENT_LIST_DIR}/impulse.44100.48000.scsa\;--log2dftlen\;16\;${TMP_DIR_PATH}/impulse.standard.44100.48000.minPhase.wav\;50000
   -P ${CMAKE_CURRENT_LIST_DIR}/execute_commands.cmake
 )
+
+add_test(NAME test_mix_channels_stereo_to_mono COMMAND "${CMAKE_COMMAND}"
+  -D "COMMAND0_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--mixChannels;0.5,0.5;--rate;48000;--bits;-64;${TMP_DIR_PATH}/sin10k.44100.wav;${TMP_DIR_PATH}/sin10k.44100.48000.mono.wav"
+  -D "COMMAND1_TO_EXECUTE=$<TARGET_FILE:cmpwav>;--check-channels;${TMP_DIR_PATH}/sin10k.44100.48000.mono.wav;1"
+  -D "COMMAND2_TO_EXECUTE=$<TARGET_FILE:scsa>;--check;${CMAKE_CURRENT_LIST_DIR}/10kHz-140dB.scsa;${TMP_DIR_PATH}/sin10k.44100.48000.mono.wav;100000;460000;10000"
+  -P ${CMAKE_CURRENT_LIST_DIR}/execute_commands.cmake
+)
+
+add_test(NAME test_mix_channels_mono_to_stereo COMMAND "${CMAKE_COMMAND}"
+  -D "COMMAND0_TO_EXECUTE=bash;-c;$<TARGET_FILE:ssrc> --profile standard --mixChannels '1;1' --rate 44100 --bits -64 ${TMP_DIR_PATH}/sin10k.mono.44100.wav ${TMP_DIR_PATH}/sin10k.mono.44100.stereo.wav"
+  -D "COMMAND1_TO_EXECUTE=$<TARGET_FILE:cmpwav>;--check-channels;${TMP_DIR_PATH}/sin10k.mono.44100.stereo.wav;2"
+  -D "COMMAND2_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--mixChannels;1,0;--rate;44100;--bits;-64;${TMP_DIR_PATH}/sin10k.mono.44100.stereo.wav;${TMP_DIR_PATH}/sin10k.mono.44100.stereo.ch0.wav"
+  -D "COMMAND3_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--mixChannels;0,1;--rate;44100;--bits;-64;${TMP_DIR_PATH}/sin10k.mono.44100.stereo.wav;${TMP_DIR_PATH}/sin10k.mono.44100.stereo.ch1.wav"
+  -D "COMMAND4_TO_EXECUTE=$<TARGET_FILE:cmpwav>;${TMP_DIR_PATH}/sin10k.mono.44100.stereo.ch0.wav;${TMP_DIR_PATH}/sin10k.mono.44100.stereo.ch1.wav;0.0001"
+  -P ${CMAKE_CURRENT_LIST_DIR}/execute_commands.cmake
+)
+
+add_test(NAME test_mix_channels_swap_stereo_channels COMMAND "${CMAKE_COMMAND}"
+  -D "COMMAND0_TO_EXECUTE=bash;-c;$<TARGET_FILE:ssrc> --profile standard --mixChannels '0,1;1,0' --rate 44100 --bits -64 ${TMP_DIR_PATH}/sin10k.44100.wav ${TMP_DIR_PATH}/sin10k.44100.swapped.wav"
+  -D "COMMAND1_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--mixChannels;1,0;--rate;44100;--bits;-64;${TMP_DIR_PATH}/sin10k.44100.wav;${TMP_DIR_PATH}/sin10k.44100.ch0.wav"
+  -D "COMMAND2_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--mixChannels;0,1;--rate;44100;--bits;-64;${TMP_DIR_PATH}/sin10k.44100.wav;${TMP_DIR_PATH}/sin10k.44100.ch1.wav"
+  -D "COMMAND3_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--mixChannels;1,0;--rate;44100;--bits;-64;${TMP_DIR_PATH}/sin10k.44100.swapped.wav;${TMP_DIR_PATH}/sin10k.44100.swapped.ch0.wav"
+  -D "COMMAND4_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--mixChannels;0,1;--rate;44100;--bits;-64;${TMP_DIR_PATH}/sin10k.44100.swapped.wav;${TMP_DIR_PATH}/sin10k.44100.swapped.ch1.wav"
+  -D "COMMAND5_TO_EXECUTE=$<TARGET_FILE:cmpwav>;${TMP_DIR_PATH}/sin10k.44100.ch0.wav;${TMP_DIR_PATH}/sin10k.44100.swapped.ch1.wav;0.0001"
+  -D "COMMAND6_TO_EXECUTE=$<TARGET_FILE:cmpwav>;${TMP_DIR_PATH}/sin10k.44100.ch1.wav;${TMP_DIR_PATH}/sin10k.44100.swapped.ch0.wav;0.0001"
+  -P ${CMAKE_CURRENT_LIST_DIR}/execute_commands.cmake
+)
+
+add_test(NAME test_mix_channels_lr_roundtrip COMMAND "${CMAKE_COMMAND}"
+  -D "COMMAND0_TO_EXECUTE=bash;-c;$<TARGET_FILE:ssrc> --profile standard --mixChannels '1,1;1,-1' --rate 44100 --bits -64 ${TMP_DIR_PATH}/sin10k.44100.wav ${TMP_DIR_PATH}/sin10k.44100.lr.wav"
+  -D "COMMAND1_TO_EXECUTE=bash;-c;$<TARGET_FILE:ssrc> --profile standard --mixChannels '0.5,0.5;0.5,-0.5' --rate 44100 --bits -64 ${TMP_DIR_PATH}/sin10k.44100.lr.wav ${TMP_DIR_PATH}/sin10k.44100.lr.restored.wav"
+  -D "COMMAND2_TO_EXECUTE=$<TARGET_FILE:cmpwav>;${TMP_DIR_PATH}/sin10k.44100.wav;${TMP_DIR_PATH}/sin10k.44100.lr.restored.wav;0.0001"
+  -P ${CMAKE_CURRENT_LIST_DIR}/execute_commands.cmake
+)
+
+add_test(NAME test_dstContainer_w64 COMMAND "${CMAKE_COMMAND}"
+  -D "COMMAND0_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--dstContainer;w64;--rate;48000;--bits;24;${TMP_DIR_PATH}/sin10k.44100.wav;${TMP_DIR_PATH}/sin10k.44100.48000.w64.wav"
+  -D "COMMAND1_TO_EXECUTE=$<TARGET_FILE:cmpwav>;--check-container;${TMP_DIR_PATH}/sin10k.44100.48000.w64.wav;w64"
+  -P ${CMAKE_CURRENT_LIST_DIR}/execute_commands.cmake
+)
+
+add_test(NAME test_dstContainer_rf64 COMMAND "${CMAKE_COMMAND}"
+  -D "COMMAND0_TO_EXECUTE=$<TARGET_FILE:ssrc>;--profile;standard;--dstContainer;rf64;--rate;48000;--bits;24;${TMP_DIR_PATH}/sin10k.44100.wav;${TMP_DIR_PATH}/sin10k.44100.48000.rf64.wav"
+  -D "COMMAND1_TO_EXECUTE=$<TARGET_FILE:cmpwav>;--check-container;${TMP_DIR_PATH}/sin10k.44100.48000.rf64.wav;rf64"
+  -P ${CMAKE_CURRENT_LIST_DIR}/execute_commands.cmake
+)
+
+add_test(
+  NAME test_mix_channels_invalid_matrix
+  COMMAND $<TARGET_FILE:ssrc> --mixChannels 1,2,3 ${TMP_DIR_PATH}/sin10k.44100.wav ${TMP_DIR_PATH}/dummy.wav
+)
+set_tests_properties(test_mix_channels_invalid_matrix PROPERTIES WILL_FAIL true)

--- a/src/tester/cmpwav.cpp
+++ b/src/tester/cmpwav.cpp
@@ -8,6 +8,14 @@
 using namespace std;
 using namespace dr_wav;
 
+string container_to_string(drwav_container container) {
+    if (container == drwav_container_riff) return "riff";
+    if (container == drwav_container_w64) return "w64";
+    if (container == drwav_container_rf64) return "rf64";
+    if (container == drwav_container_aiff) return "aiff";
+    return "unknown";
+}
+
 double compare(const string& file0, const string& file1) {
   static const size_t N = 4096;
 
@@ -38,7 +46,13 @@ double compare(const string& file0, const string& file1) {
 }
 
 int main(int argc, char **argv) {
-  if (argc == 4) {
+  if (argc == 4 && string(argv[1]) == "--check-channels") {
+    WavFile wav(argv[2]);
+    return wav.getNChannels() == stoul(argv[3]) ? 0 : 1;
+  } else if (argc == 4 && string(argv[1]) == "--check-container") {
+    WavFile wav(argv[2]);
+    return container_to_string(wav.getContainer()) == argv[3] ? 0 : 1;
+  } else if (argc == 4) {
     try {
       double maxDif = compare(argv[1], argv[2]);
       cerr << "Max difference : " << maxDif << endl;
@@ -48,6 +62,8 @@ int main(int argc, char **argv) {
     }
   } else {
     cerr << "Usage : " << argv[0] << " <file0.wav> <file1.wav> <threshold>" << endl;
+    cerr << " or " << argv[0] << " --check-channels <file.wav> <# of channels>" << endl;
+    cerr << " or " << argv[0] << " --check-container <file.wav> <container>" << endl;
   }
 
   return -1;


### PR DESCRIPTION
This commit introduces a comprehensive test suite for the `--mixChannels` and `--dstContainer` options in the `ssrc` command-line tool.

The `cmpwav` utility has been extended with `--check-channels` and `--check-container` options to support the new tests.

The following test cases have been added to `src/tester/CMakeLists.txt`:
- `test_mix_channels_stereo_to_mono`: Verifies stereo to mono conversion.
- `test_mix_channels_mono_to_stereo`: Verifies mono to stereo conversion.
- `test_mix_channels_swap_stereo_channels`: Verifies swapping of stereo channels.
- `test_mix_channels_lr_roundtrip`: Verifies a round-trip conversion from stereo to L+R/L-R and back to stereo.
- `test_dstContainer_w64`: Verifies the use of the `w64` container.
- `test_dstContainer_rf64`: Verifies the use of the `rf64` container.
- `test_mix_channels_invalid_matrix`: Verifies that an invalid matrix is correctly handled.