### PR TITLE
docs: Add documentation for the new peak operator in scsa

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,15 @@ The check file is a plain text file that defines the spectral criteria for the `
   `<low_freq> <high_freq> <comparison> <threshold_db>`
   - `<low_freq>`: The lower bound of the frequency range in Hz (double).
   - `<high_freq>`: The upper bound of the frequency range in Hz (double).
-  - `<comparison>`: The comparison operator, which must be either `<` (less than) or `>` (greater than).
+  - `<comparison>`: The comparison operator. Can be one of `<` (less than), `>` (greater than), or `^` (peak).
   - `<threshold_db>`: The threshold value in decibels (double).
 
 - **Comments**: Lines starting with a `#` character are treated as comments and are ignored. Empty lines are also ignored.
 
-- **Logic**: For a check to pass, **all** frequency components of the signal that fall within the `[low_freq, high_freq]` range must satisfy the condition.
-  - If the comparison is `<`, every spectral point in the range must be below the threshold.
-  - If the comparison is `>`, every spectral point in the range must be above the threshold.
+- **Logic**: The check logic depends on the comparison operator:
+  - **`<`**: Checks if **all** frequency components in the range are **less than** the threshold.
+  - **`>`**: Checks if **all** frequency components in the range are **greater than** the threshold.
+  - **`^`**: Checks if the **peak** frequency component in the range is **greater than or equal to** the threshold.
 
 - **Example**:
   ```

--- a/src/cli/scsa.1
+++ b/src/cli/scsa.1
@@ -40,7 +40,18 @@ The lower bound of the frequency range in Hz.
 The upper bound of the frequency range in Hz.
 .IP
 .B <comparison>
-The comparison operator, either \fB<\fR (less than) or \fB>\fR (greater than).
+The comparison operator. Can be one of the following:
+.RS
+.TP
+\fB<\fR
+Checks if all frequency components in the range are less than the threshold.
+.TP
+\fB>\fR
+Checks if all frequency components in the range are greater than the threshold.
+.TP
+\fB^\fR
+Checks if the peak frequency component in the range is greater than or equal to the threshold.
+.RE
 .IP
 .B <threshold_db>
 The threshold value in decibels.


### PR DESCRIPTION
The `scsa` command-line tool has been updated with a new `^` operator for its check file functionality. This operator checks if the peak frequency component within a specified range is greater than or equal to a given threshold.

This change updates the following documentation to reflect the new operator:
- `src/cli/scsa.1` (the man page)
- `README.md`